### PR TITLE
Add style for code and table items

### DIFF
--- a/entrypoints/content/style.css
+++ b/entrypoints/content/style.css
@@ -115,5 +115,5 @@ code {
 .table, .alert.alert-info>table, .alert.alert-caution>table, .alert.alert-danger>table, .td-content table, .td-box .row.section>table {
   width: 100%;
   margin-bottom: 1rem;
-  /* color: #222; */
+  color: #d4d4d4;
 }

--- a/entrypoints/content/style.css
+++ b/entrypoints/content/style.css
@@ -105,3 +105,15 @@ body .alert h4 {
   background-color: var(--crx-background1) !important;
   color: var(--crx-foreground) !important;
 }
+
+code {
+  font-size: 87.5%;
+  color: #3bdd60; /* Changed to green */
+  word-wrap: break-word;
+}
+
+.table, .alert.alert-info>table, .alert.alert-caution>table, .alert.alert-danger>table, .td-content table, .td-box .row.section>table {
+  width: 100%;
+  margin-bottom: 1rem;
+  /* color: #222; */
+}

--- a/entrypoints/content/style.css
+++ b/entrypoints/content/style.css
@@ -108,12 +108,17 @@ body .alert h4 {
 
 code {
   font-size: 87.5%;
-  color: #3bdd60; /* Changed to green */
-  word-wrap: break-word;
+  color: #d4d4d4 !important;
+  word-wrap: break-word
 }
 
-.table, .alert.alert-info>table, .alert.alert-caution>table, .alert.alert-danger>table, .td-content table, .td-box .row.section>table {
+.table,
+.alert.alert-info>table,
+.alert.alert-caution>table,
+.alert.alert-danger>table,
+.td-content table,
+.td-box .row.section>table {
   width: 100%;
   margin-bottom: 1rem;
-  color: #d4d4d4;
+  color: #d4d4d4 !important
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "crx-kubernetes-darkmode",
   "description": "Dark Mode for Kubernetes.io",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
This PR tries to fix the rendering issues described in issue #2 .

Code and table items are now light gray (`#d4d4d4`), in line with the text color.

Example:

URL: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
<img width="1201" height="488" alt="image" src="https://github.com/user-attachments/assets/a6fe503d-7a58-47b5-af59-06944d68d729" />

I have validated it on Brave browser and it works for me.

Fixes #2 